### PR TITLE
Authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
 
   :dependencies
   [[aleph "0.4.7-alpha1"]
+   [buddy/buddy-sign "3.1.0"]
    [camel-snake-kebab "0.4.0"]
    [cheshire "5.9.0"]
    [com.cognitect/anomalies "0.1.12"]

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
 
   :dependencies
   [[aleph "0.4.7-alpha1"]
+   [buddy/buddy-core "1.6.0"]
    [buddy/buddy-sign "3.1.0"]
    [camel-snake-kebab "0.4.0"]
    [cheshire "5.9.0"]

--- a/src/blaze/handler/app.clj
+++ b/src/blaze/handler/app.clj
@@ -1,6 +1,7 @@
 (ns blaze.handler.app
   (:require
     [blaze.middleware.json :refer [wrap-json]]
+    [blaze.middleware.auth :refer [wrap-auth]]
     [blaze.middleware.fhir.type :refer [wrap-type]]
     [clojure.spec.alpha :as s]
     [reitit.core :as reitit]
@@ -25,7 +26,7 @@
       {:middleware [wrap-json wrap-remove-context-path]
        :handler (:handler.fhir/core handlers)}]
      ["/fhir/{*more}"
-      {:middleware [wrap-json wrap-remove-context-path]
+      {:middleware [wrap-json wrap-auth wrap-remove-context-path]
        :handler (:handler.fhir/core handlers)}]]
     {:syntax :bracket
      ::reitit-ring/default-options-handler

--- a/src/blaze/handler/app.clj
+++ b/src/blaze/handler/app.clj
@@ -1,7 +1,7 @@
 (ns blaze.handler.app
   (:require
     [blaze.middleware.json :refer [wrap-json]]
-    [blaze.middleware.auth :refer [wrap-auth]]
+    [blaze.middleware.authentication :refer [wrap-authentication]]
     [blaze.middleware.fhir.type :refer [wrap-type]]
     [clojure.spec.alpha :as s]
     [reitit.core :as reitit]
@@ -26,7 +26,7 @@
       {:middleware [wrap-json wrap-remove-context-path]
        :handler (:handler.fhir/core handlers)}]
      ["/fhir/{*more}"
-      {:middleware [wrap-json wrap-auth wrap-remove-context-path]
+      {:middleware [wrap-json wrap-authentication wrap-remove-context-path]
        :handler (:handler.fhir/core handlers)}]]
     {:syntax :bracket
      ::reitit-ring/default-options-handler

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -57,11 +57,12 @@
       nil)))
 
 
+;; TODO: Store/manage this using Integrant?
 (def public-key-atom (atom (public-key-atom-value nil)))
 
 
 (defn wrap-auth
-  "Adds an Access-Control-Allow-Origin header with the value * to responses."
+  "If successful process request, else respond with 403."
   [handler]
   (fn [request]
     (let [response     (handler request)

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -22,6 +22,7 @@
    :timestamp  (.getTime (Date.))})
 
 
+;; TODO: Possibly make the expiration time configurable
 (defn- public-key-str
   "When the public key atom is more than 1 hour old, update the public key.
    Always return the public key."

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -63,5 +63,5 @@
           auth-header (get-in request [:headers "authorization"])
           token       (unsigned-token public-key-atom auth-header)]
       (prn token)
-      ;; TODO: Insert the token into the response
+      ;; TODO: Insert the token into the response. Will possibly handle 403 here.
       response)))

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -1,0 +1,67 @@
+(ns blaze.middleware.auth
+  (:require
+   [buddy.sign.jwt :as jwt]
+   [cheshire.core :as json]
+   #_[manifold.deferred :as md])
+  (:import
+   (java.util Base64 Date)
+   (java.security KeyFactory)
+   (java.security.spec X509EncodedKeySpec)))
+
+
+;; TODO: This url needs to be configurable, probably via an env var
+(defn- keycloak-public-key []
+  (-> "https://auth.breezeehr.com/auth/realms/patient-portal"
+      slurp
+      json/parse-string
+      (get "public_key")))
+
+
+(defn- public-key-atom-value [_]
+  {:public-key (keycloak-public-key)
+   :timestamp  (.getTime (Date.))})
+
+
+(defn- public-key-str
+  "When the public key atom is more than 1 hour old, update the public key.
+   Always return the public key."
+  [public-key-atom]
+  (do
+    (when (< 3600000 (- (.getTime (Date.)) (:timestamp @public-key-atom)))
+      (swap! public-key-atom public-key-atom-value))
+    (:public-key @public-key-atom)))
+
+
+(defn- str->public-key [s]
+  (->> s
+       #^bytes .getBytes
+       (.decode (Base64/getDecoder))
+       X509EncodedKeySpec.
+       (.generatePublic (KeyFactory/getInstance "RSA"))))
+
+
+(defn- unsigned-token [public-key-atom token]
+  (try
+    ;; TODO (first): Figure out why the token is invalid when it is valid... only difference from previous is cheshire and passing atom around
+    (jwt/unsign token (str->public-key (public-key-str public-key-atom)) {:alg :rs256})
+    (catch Exception e
+      ;; TODO: Figure out correct response. I was initially using nil because
+      ;; that's what Geheimtur wanted.
+      (prn (:cause (Throwable->map e)))
+      nil)))
+
+
+;; TODO: Don't use a global state atom, I think
+(def public-key-atom (atom (public-key-atom-value nil)))
+
+(defn wrap-auth
+  "Adds an Access-Control-Allow-Origin header with the value * to responses."
+  [handler]
+  (fn [request]
+    (println "wrap-auth")
+    (let [response    (handler request)
+          auth-header (get-in request [:headers "authorization"])
+          token       (unsigned-token public-key-atom auth-header)]
+      (prn token)
+      ;; TODO: Insert the token into the response
+      response)))

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -15,7 +15,7 @@
 (def expiration-minutes 60)
 
 
-;; TODO: This url needs to be configurable, probably via an env var
+;; TODO: This url or even this function needs to be configurable
 (defn- keycloak-public-key []
   (-> "https://auth.breezeehr.com/auth/realms/patient-portal"
       slurp
@@ -57,8 +57,8 @@
       nil)))
 
 
-;; TODO: Don't use a global state atom?
 (def public-key-atom (atom (public-key-atom-value nil)))
+
 
 (defn wrap-auth
   "Adds an Access-Control-Allow-Origin header with the value * to responses."

--- a/src/blaze/middleware/auth.clj
+++ b/src/blaze/middleware/auth.clj
@@ -10,6 +10,7 @@
    (java.security KeyFactory)
    (java.security.spec X509EncodedKeySpec)))
 
+;; TODO Probably should be renamed to authentication.clj and all names updated accordingly
 
 ;; TODO: Possibly make the expiration time configurable
 (def expiration-minutes 60)

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -18,7 +18,10 @@
 (def ^:private expiration-minutes 60)
 
 
-(defn- public-key [url]
+(defn- public-key
+  "From the OpenID Configuration url, follow the `jwks_uri` to get the
+   first jwk."
+  [url]
   (-> url
       slurp
       json/parse-string
@@ -47,7 +50,8 @@
     public-key-atom))
 
 
-(defn- unsigned-token [public-key-atom signed-token]
+(defn- unsigned-token
+  [public-key-atom signed-token]
   (try
     (let [public-key (:public-key @(updated-public-key-atom public-key-atom))]
       (jwt/unsign signed-token public-key {:alg :rs256}))

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -10,9 +10,7 @@
    [ring.util.response :as ring]
    #_[manifold.deferred :as md])
   (:import
-   (java.util Base64 Date)
-   (java.security KeyFactory)
-   (java.security.spec X509EncodedKeySpec)))
+   (java.util Date)))
 
 
 (defn- public-key

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -70,13 +70,16 @@
   [public-key-atom]
   (fn [handler]
     (fn [request]
-      (if (nil? public-key-atom) ;; If there is no atom, skip authorization
+      ;; If there is no atom, skip authorization. Otherwise, continue authorization.
+      (if (nil? public-key-atom)
         (handler request)
         (let [auth-header (get-in request [:headers "authorization"])]
-          (if (string/blank? auth-header) ;; If auth header is nil or empty, inform client
+          ;; If auth header is nil or empty, inform client. Otherwise, continue authorization.
+          (if (string/blank? auth-header)
             (unauthenticated-response "Missing authorization header")
             (let [bearer-token (string/replace auth-header "Bearer " "")
                   token        (unsigned-token public-key-atom bearer-token)]
-              (if (string? token) ;; If token is a string, it really is an error message, pass along to client (TODO: Is this too much info to expose?)
+              ;; If token is a string, it is actually the error message. Otherwise, authorization succeeded.
+              (if (string? token)
                 (unauthenticated-response token)
                 (handler request)))))))))

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -35,7 +35,7 @@
   (do
     (when (< (* expiration-minutes 60000)
              (- (.getTime (Date.)) (:timestamp @public-key-atom)))
-      (swap! public-key-atom public-key-atom-value))
+      (swap! public-key-atom public-key-atom-value (:openid-url @public-key-atom)))
     (:public-key @public-key-atom)))
 
 
@@ -64,10 +64,10 @@
 (defn wrap-authentication
   "If successful process request, else respond with 403. Update the
   public key when necessary."
-  [openid-url public-key-atom]
+  [public-key-atom]
   (fn [handler]
     (fn [request]
-      (if (string/blank? openid-url) ;; If string is nil or empty, skip authentication
+      (if (nil? public-key-atom) ;; If atom is nil, skip authentication
         (handler request)
         (let [auth-header (get-in request [:headers "authorization"])]
           (if (string/blank? auth-header) ;; If auth header is nil or empty, inform client

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -1,4 +1,4 @@
-(ns blaze.middleware.auth
+(ns blaze.middleware.authentication
   (:require
    [clojure.string :as string]
    [buddy.sign.jwt :as jwt]
@@ -10,7 +10,7 @@
    (java.security KeyFactory)
    (java.security.spec X509EncodedKeySpec)))
 
-;; TODO Probably should be renamed to authentication.clj and all names updated accordingly
+;; TODO: Should I have used https://funcool.github.io/buddy-auth/latest/api/buddy.auth.middleware.html#var-wrap-authentication instead?
 
 ;; TODO: Possibly make the expiration time configurable
 (def expiration-minutes 60)
@@ -62,11 +62,11 @@
 (def public-key-atom (atom (public-key-atom-value nil)))
 
 
-(defn wrap-auth
+(defn wrap-authentication
   "If successful process request, else respond with 403."
   [handler]
   (fn [request]
-    ;; TODO: If auth is enabled (via env var)
+    ;; TODO: If authentication is enabled (via env var)
     (let [auth-header     (get-in request [:headers "authorization"])
           denied-response (-> (ring/response {:message "Access denied"})
                               (ring/status 403))]

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -7,8 +7,7 @@
    [buddy.core.keys :as keys]
    [buddy.sign.jwt :as jwt]
    [cheshire.core :as json]
-   [ring.util.response :as ring]
-   #_[manifold.deferred :as md])
+   [ring.util.response :as ring])
   (:import
    (java.util Date)))
 

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -1,6 +1,10 @@
 (ns blaze.middleware.authentication
+  "Ring middleware that verifies a signed JWT using OpenID Connect
+   to provide the public key used to sign the token. The public key
+   is stored in an atom that is updated every `expiration-minutes`."
   (:require
    [clojure.string :as string]
+   [buddy.core.keys :as keys]
    [buddy.sign.jwt :as jwt]
    [cheshire.core :as json]
    [ring.util.response :as ring]
@@ -10,31 +14,29 @@
    (java.security KeyFactory)
    (java.security.spec X509EncodedKeySpec)))
 
-;; https://auth.breezeehr.com/auth/realms/patient-portal/.well-known/openid-configuration
+
+(def ^:private expiration-minutes 60)
 
 
-(def ^:private expiration-minutes 1)
-
-
-;; TODO: Acutally use proper OpenID methods
-(defn- get-public-key [url]
+(defn- public-key [url]
   (-> url
       slurp
       json/parse-string
-      (get "issuer")
+      (get "jwks_uri")
       slurp
-      json/parse-string
-      (get "public_key")))
+      (json/parse-string keyword)
+      :keys ;; Buddy expects keywords, not strings
+      first
+      keys/jwk->public-key))
 
 
-;; TODO: Figure out if I can do this with only one argument
 (defn public-key-atom-value [v]
-  {:public-key (get-public-key (:openid-url v))
+  {:public-key (public-key (:openid-url v))
    :timestamp  (.getTime (Date.))
    :openid-url (:openid-url v)})
 
 
-(defn- public-key-str
+(defn- updated-public-key-atom
   "When the public key atom is more than `expiration-minutes` old,
    update the public key. Always return the public key."
   [public-key-atom]
@@ -42,27 +44,18 @@
     (when (< (* expiration-minutes 60000)
              (- (.getTime (Date.)) (:timestamp @public-key-atom)))
       (swap! public-key-atom public-key-atom-value))
-    (:public-key @public-key-atom)))
-
-
-(defn- str->public-key [s]
-  (->> s
-       #^bytes .getBytes
-       (.decode (Base64/getDecoder))
-       X509EncodedKeySpec.
-       (.generatePublic (KeyFactory/getInstance "RSA"))))
+    public-key-atom))
 
 
 (defn- unsigned-token [public-key-atom signed-token]
   (try
-    (let [public-key (str->public-key (public-key-str public-key-atom))]
+    (let [public-key (:public-key @(updated-public-key-atom public-key-atom))]
       (jwt/unsign signed-token public-key {:alg :rs256}))
     (catch Exception e
-      ;; Return nil to signal failure to unsign token
       (:cause (Throwable->map e)))))
 
 
-(defn unauthenticated-response [message]
+(defn- unauthenticated-response [message]
   (-> (ring/response {:message message})
       (ring/status 403)))
 
@@ -78,8 +71,8 @@
         (let [auth-header (get-in request [:headers "authorization"])]
           (if (string/blank? auth-header) ;; If auth header is nil or empty, inform client
             (unauthenticated-response "Missing authorization header")
-            (let [bearer-token    (string/replace auth-header "Bearer " "")
-                  token           (unsigned-token public-key-atom bearer-token)]
+            (let [bearer-token (string/replace auth-header "Bearer " "")
+                  token        (unsigned-token public-key-atom bearer-token)]
               (if (string? token) ;; If token is a string, it really is an error message, pass along to client (TODO: Is this too much info to expose?)
                 (unauthenticated-response token)
                 (handler request)))))))))

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -274,8 +274,6 @@
   (d/connect uri))
 
 
-;; TODO: I think this should return a function that updates
-;; the keycloak-public-key-atom if necessary
 (defmethod ig/init-key :authorization-service
   [_ {:keys [name url]}]
   (case name

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -57,8 +57,7 @@
 (s/def :config/logging (s/keys :opt [:log/level]))
 (s/def :database/uri string?)
 (s/def :config/database-conn (s/keys :opt [:database/uri]))
-(s/def :authorization-service/name string?)
-(s/def :authorization-service/url string?)
+(s/def :authorization/url string?)
 (s/def :config/authorization (s/keys :opt-un [:authorization/url]))
 (s/def :term-service/uri string?)
 (s/def :term-service/proxy-host string?)
@@ -197,7 +196,7 @@
      :handler/health (ig/ref :health-handler)
      :handler.fhir/core (ig/ref :fhir-core-handler)}
     :middleware
-    {:middleware/authorization (ig/ref :authorization-service)}}
+    {:middleware/authorization (ig/ref :authorization)}}
 
    :server-executor {}
 
@@ -274,7 +273,7 @@
 
 (defmethod ig/init-key :authorization
   [_ {:keys [url]}]
-  (let [public-key-atom (when url (atom authentication/public-key-atom-value url))]
+  (let [public-key-atom (when url (atom (authentication/public-key-atom-value nil url)))]
     (authentication/wrap-authentication public-key-atom)))
 
 

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -36,7 +36,6 @@
     [blaze.server :as server]
     [blaze.structure-definition :refer [read-structure-definitions]]
     [blaze.terminology-service.extern :as ts]
-    [cheshire.core :as j]
     [datomic.api :as d]
     [datomic-tools.schema :as dts]
     [integrant.core :as ig]

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -32,7 +32,7 @@
     [blaze.metrics :as metrics]
     [blaze.middleware.fhir.metrics :as fhir-metrics]
     [blaze.middleware.json :as json]
-    [blaze.middleware.authentication :as authentication ]
+    [blaze.middleware.authentication :as authentication]
     [blaze.server :as server]
     [blaze.structure-definition :refer [read-structure-definitions]]
     [blaze.terminology-service.extern :as ts]

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -46,7 +46,7 @@
                                          ClassLoadingExports VersionInfoExports]
            [java.time Clock]))
 
-;; TODO: Figure out how to pass the resulting public key into the authorization middleware
+
 
 ;; ---- Specs -------------------------------------------------------------
 

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -273,7 +273,7 @@
 
 (defmethod ig/init-key :authorization
   [_ {:keys [url]}]
-  (let [public-key-atom (when url (atom (authentication/public-key-atom-value nil url)))]
+  (let [public-key-atom (when url (atom (authentication/public-key-atom-value {:openid-url url})))]
     (authentication/wrap-authentication public-key-atom)))
 
 

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -274,9 +274,8 @@
 
 (defmethod ig/init-key :authorization
   [_ {:keys [url]}]
-  ;; TODO: Initialize public key
-  (let [public-key-atom (atom authentication/public-key-atom-value url)])
-  (authentication/wrap-authentication public-key-atom))
+  (let [public-key-atom (when url (atom authentication/public-key-atom-value url))]
+    (authentication/wrap-authentication public-key-atom)))
 
 
 (defmethod ig/init-key :term-service

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -276,6 +276,7 @@
 
 (defmethod ig/init-key :authorization-service
   [_ {:keys [name url]}]
+  ;; TODO: Must validate that `url` is non-nil is `name` is known.
   (case name
     "keycloak" (authentication/wrap-authentication (atom (authentication/public-key-atom-value
                                                           nil

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -59,9 +59,7 @@
 (s/def :config/database-conn (s/keys :opt [:database/uri]))
 (s/def :authorization-service/name string?)
 (s/def :authorization-service/url string?)
-(s/def :config/authorization-service
-  (s/keys :opt-un [:authorization-service/name
-                   :authorization-service/url]))
+(s/def :config/authorization (s/keys :opt-un [:authorization/url]))
 (s/def :term-service/uri string?)
 (s/def :term-service/proxy-host string?)
 (s/def :term-service/proxy-port pos-int?)
@@ -90,7 +88,7 @@
     :opt-un
     [:config/logging
      :config/database-conn
-     :config/authorization-service
+     :config/authorization
      :config/term-service
      :config/cache
      :config/fhir-capabilities-handler
@@ -115,7 +113,7 @@
    {:structure-definitions (ig/ref :structure-definitions)
     :database/uri "datomic:mem://dev"}
 
-   :authorization-service {}
+   :authorization {}
 
    :term-service
    {:uri "http://tx.fhir.org/r4"}
@@ -274,14 +272,11 @@
   (d/connect uri))
 
 
-(defmethod ig/init-key :authorization-service
-  [_ {:keys [name url]}]
-  ;; TODO: Must validate that `url` is non-nil is `name` is known.
-  (case name
-    "keycloak" (authentication/wrap-authentication (atom (authentication/public-key-atom-value
-                                                          nil
-                                                          authentication/keycloak-public-key)))
-    (authentication/wrap-authentication nil)))
+(defmethod ig/init-key :authorization
+  [_ {:keys [url]}]
+  ;; TODO: Initialize public key
+  (let [public-key-atom (atom authentication/public-key-atom-value url)])
+  (authentication/wrap-authentication public-key-atom))
 
 
 (defmethod ig/init-key :term-service

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -273,7 +273,7 @@
 
 (defmethod ig/init-key :authorization
   [_ {:keys [url]}]
-  (let [public-key-atom (when url (atom (authentication/public-key-atom-value {:openid-url url})))]
+  (let [public-key-atom (when (not-empty url) (atom (authentication/public-key-atom-value {:openid-url url})))]
     (authentication/wrap-authentication public-key-atom)))
 
 

--- a/test/blaze/handler/app_test.clj
+++ b/test/blaze/handler/app_test.clj
@@ -30,9 +30,11 @@
    :handler/health (fn [_] ::health-handler)
    :handler.fhir/core (fn [_] ::fhir-core-handler)})
 
+(def ^:private middleware
+  {:middleware/authorization (fn [_] ::authorization-service)})
 
 (def ^:private test-handler
-  (reitit-ring/ring-handler (router handlers)))
+  (reitit-ring/ring-handler (router handlers middleware)))
 
 
 (defn- match [path request-method]


### PR DESCRIPTION
## Summary

To add authentication to Blaze, I created a middleware that will try to verify a Signed JWT when the environment variable `AUTHORIZATION_URL` is a non-empty string.

This PR depends on an external OAuth2 provider to provide and sign the tokens. For example, [Keycloak](https://www.keycloak.org/).

## New Dependencies

- `[buddy/buddy-core "1.6.0"]` for preparing the public key used to verify the token
- `[buddy/buddy-sign "3.1.0"]` for verifying the authenticity of the token's signature

## Authentication functionality

To authenticate the clinical end-user (often, but not always, the patient), [FHIR specifies](http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#scopes-for-requesting-identity-data) that [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) is used.

- The url in the `AUTHORIZATION_URL` must be an [OpenID Configuration url](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) which provides a `jwks_uri` property
- Following the `jwks_uri` property leads to a json wrapped set of keys
- At present, my implementation only looks at the first of these keys
- This key is stored in a `clojure` atom and updated every X number of minutes (currently hardcoded to `60`, but could be configurable in the future.)
- The public key from the atom is used to verify the signature of the authorization header bearer token.

## Architecture within Blaze

### Summary of Changes

I modified `blaze.handler.app/handler` and `blaze.handler.app/router` to accept a collection `middleware` alongside the `handler` collection. This was necessary to pass in configuration data from Integrant. 

I expect you will have some opinions about this decision.

### Details

- Specs and configs are added for `authorization` its child `url` in _system.clj_
- Most notably, a `:middleware` property has been added to the `:app-handler` map in [system.clj:198](https://github.com/Breezeemr/blaze/pull/1/files#diff-65f5856be49a96dfce50af7ac7522e33R198-R199)
  - This change is reflected in the `:app-handler` init function at [src/blaze/system.clj:394](https://github.com/Breezeemr/blaze/pull/1/files#diff-65f5856be49a96dfce50af7ac7522e33R394-R395)
  - This same change continues into [src/blaze/handler/app.clj](https://github.com/Breezeemr/blaze/pull/1/files#diff-637d480758abc997cb2ca7597d0caa6b) where all the changes are related to passing the list of middleware into the router. Previous middleware was not configured via Integrant so did not need to be passed in this way, I have not touched any related to other middleware.
  - Lastly, the test in [test/blaze/handler/app_test.clj:37](https://github.com/Breezeemr/blaze/compare/master...Breezeemr:auth?diff=split&expand=1#diff-600823e4ff2df4a145761a133ae4021aR37) must also be updated to account for this change

## Questions

- Should other middleware (e.g. `blaze.middleware.json`) that does not depend on external configuration be migrated to the Integrant-oriented approach or left as is?
- Do you have any preferred naming conventions?

